### PR TITLE
Convert all years to leap years

### DIFF
--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -101,8 +101,7 @@ def get_data(url):
     ds = xr.open_dataset(nc_url)
     ds = ds.sel(nv=0)
     df = ds.to_dataframe()
-    df = df.droplevel(1)
-    df = df[~df.index.duplicated(keep='first')]
+
     # Check whether to fetch Sea Ice Extent or Sea Ice Area.
     try:
         df["sie"]


### PR DESCRIPTION
This PR consists of two commits:

- The first one removes some de-duplication code that is not needed due to `nv=0` already being selected in the data. I've checked to be sure that this doesn't remove any attributes from the data.

- The second one deals with the issue of leap years. The approach I've chosen is to convert all years to leap years and to fill February 29th with data interpolated between February 28th and March 1st for non-leap years.