### PR TITLE
Rewrite code to use Bokeh only

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visualization tools for the Sea Ice Indexes
 
 * **Bokeh APP:**
 
-   https://mybinder.org/v2/gh/metno/sea-ice-index-viz/main?urlpath=/proxy/5006/bokeh-app    
+   https://mybinder.org/v2/gh/huaracheguarache/sea-ice-index-viz/rewrite?urlpath=%2Fproxy%2F5006%2Fbokeh-app
 
 
 ### Local deployment

--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -1,6 +1,6 @@
 import xarray as xr
 from bokeh.plotting import figure
-from bokeh.models import Panel, Tabs, ColumnDataSource, AdaptiveTicker, Select, MultiChoice, HoverTool
+from bokeh.models import Panel, Tabs, ColumnDataSource, AdaptiveTicker, Select, MultiChoice, HoverTool, DataRange1d
 from bokeh.layouts import column, row
 from bokeh.io import curdoc
 import numpy as np
@@ -67,7 +67,7 @@ def prepare_plot_data(index, area, years):
 
 
 def make_plot(column_data_source, title, long_name, units):
-    inner_plot = figure(title=title, x_range=(1, 366), y_range=(0, 18))
+    inner_plot = figure(title=title, x_range=(1, 366), y_range=(DataRange1d(start=0)))
     inner_plot.multi_line(xs="day_of_year", ys="data", source=column_data_source, line_width=2)
 
     x_ticks = {1: '1 Jan',
@@ -92,17 +92,9 @@ def make_plot(column_data_source, title, long_name, units):
     inner_plot.yaxis.ticker = AdaptiveTicker(base=10, mantissas=[2])
     inner_plot.yaxis.axis_label = f"{long_name} - {units}"
 
-    inner_plot.add_tools(
-        HoverTool(
-            show_arrow=False,
-            line_policy='next',
-            tooltips=[
-                ("Year", "@year"),
-                ('Day of year', '$data_x'),
-                ('Index value', '$data_y')
-            ]
-            )
-        )
+    inner_plot.add_tools(HoverTool(tooltips=[("Year", "@year"),
+                                             ('Day of year', '$data_x'),
+                                             ('Index value', '$data_y')]))
 
     return inner_plot
 

--- a/docker/bokeh/dockerfile
+++ b/docker/bokeh/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.10.5-slim-buster
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/bokeh/requirements.txt
+++ b/docker/bokeh/requirements.txt
@@ -1,6 +1,4 @@
 netcdf4
 xarray
-pandas
 bokeh
-panel
-holoviews
+numpy


### PR DESCRIPTION
I got a bit frustrated with Holoviews' lack of function documentation, so I spent some time on the radical solution of rewriting the code to only use Bokeh (without Holoviews and Panel). I've edited the Docker files to make sure that it is able to run.

I've also partially addressed the leap year issue. What happens now is that a data point is only plotted for leap years at February 29th, but not for non-leap years. Non-leap years simply have a continuous line that is interpolated between the value at the 28th of February and the 1st of March. This means that a hovertool does not appear when you point your cursor at the 29th of February for a non-leap year.

This is all jolly good, but there is still one issue. The hovertool displays the day of year based on what the x-coordinate of a given point on the graph is. To not plot a point on the 29th of February for non-leap years I simply skip that x-coordinate when plotting them. This leads to the hovertool displaying the day of year for non-leap years as one too many compared to the actual value after the 29th of February. One potential way of solving this would be to simply include another column in the data that is provided to multi_line with a separate day of year coordinate to be displayed in the hovertool. The issue with this is that multi_line would print all of the values in the column instead of the one associated with the given coordinate: https://github.com/bokeh/bokeh/issues/7969