### PR TITLE
Add decade selection to climatology

### DIFF
--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -164,7 +164,13 @@ area_selector = Select(title="Area:", value="Northern Hemisphere",
 # Add a dropdown menu for selecting the reference period of the percentile and median plots.
 reference_period_selector = Select(title="Reference period of percentiles and median:",
                                    value="1981-2010",
-                                   options=["1981-2010", "1991-2020"])
+                                   options=[("1981-2010", "1981-2010"),
+                                            ("1991-2020", "1991-2020"),
+                                            ("1980-1989", "1980s"),
+                                            ("1990-1999", "1990s"),
+                                            ("2000-2009", "2000s"),
+                                            ("2010-2019", "2010s"),
+                                            ("2020-2029", "2020s")])
 
 # Download the data for the default index and area values.
 ds = download_dataset(index_selector.value, area_selector.value)


### PR DESCRIPTION
I've added the decades to the same dropdown menu as the other reference periods used for the climatology. @TomLav you only mentioned the median and 25-75 percentile in the issue, but in this PR I'm also plotting the 10-90 percentile. Do you only want the 25-75 percentile to be plotted?

Here's the binder instance: https://mybinder.org/v2/gh/huaracheguarache/sea-ice-index-viz/new_climatology?urlpath=%2Fproxy%2F5006%2Fbokeh-app

Closes #12.