### PR TITLE
Hovertool improvements

### DIFF
--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -102,8 +102,6 @@ minimum = plot.line(x="day_of_year",
 
 legend_list.append(("Minimum", [minimum]))
 
-plot.add_tools(HoverTool(renderers=[minimum], tooltips=[('Day of year', '$data_x'), ('Minimum value', '$data_y')]))
-
 maximum = plot.line(x="day_of_year",
                     y="maximum",
                     source=cds_maximum,
@@ -113,8 +111,6 @@ maximum = plot.line(x="day_of_year",
                     line_dash="dashed")
 
 legend_list.append(("Maximum", [maximum]))
-
-plot.add_tools(HoverTool(renderers=[maximum], tooltips=[('Day of year', '$data_x'), ('Maximum value', '$data_y')]))
 
 
 # Plot the individual years.

--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -58,7 +58,7 @@ cds_minimum = min_max_dict["cds_minimum"]
 cds_maximum = min_max_dict["cds_maximum"]
 
 # Calculate index of individual years.
-cds_individual_years = tk.calculate_individual_years(da)
+cds_individual_years = tk.calculate_individual_years(da, da_converted)
 
 
 # Plot the figure and make sure that it uses all available space.
@@ -149,10 +149,26 @@ for sublist in legend_split:
 plot.legend.click_policy = "hide"
 
 # Add a hovertool to display the year, day of year, and index value of the individual years.
+TOOLTIPS = """
+    <div>
+        <div>
+            <span style="font-size: 12px; font-weight: bold">Date:</span>
+            <span style="font-size: 12px;">@date</span>
+        </div>
+        <div>
+            <span style="font-size: 12px; font-weight: bold">Index:</span>
+            <span style="font-size: 12px;">@index_values</span>
+            <span style="font-size: 12px;">mill. km<sup>2</sup></span>
+        </div>
+        <div>
+            <span style="font-size: 12px; font-weight: bold">Rank:</span>
+            <span style="font-size: 12px;">@rank</span>
+        </div>
+    </div>
+"""
+
 plot.add_tools(HoverTool(renderers=individual_years_glyphs,
-                         tooltips=[("Date", "@date"),
-                                   ('Day of year', '@day_of_year'),
-                                   ('Index value', '@index_values')]))
+                         tooltips=TOOLTIPS))
 
 # Hardcode the x-ticks (day_of_year, date).
 plot.x_range = Range1d(start=1, end=366)
@@ -260,7 +276,7 @@ def update_data(attr, old, new):
     cds_maximum.data.update(min_max_dict["cds_maximum"].data)
 
     # Calculate new columndatasources for the individual years.
-    new_cds_individual_years = tk.calculate_individual_years(da)
+    new_cds_individual_years = tk.calculate_individual_years(da, da_converted)
     # Update the existing columndatasources with the new data.
     for new_cds, old_cds in zip(new_cds_individual_years.values(), cds_individual_years.values()):
         old_cds.data.update(new_cds.data)

--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -78,9 +78,12 @@ def calculate_min_max(da):
     return {"cds_minimum": cds_minimum, "cds_maximum": cds_maximum}
 
 
-def calculate_individual_years(da):
+def calculate_individual_years(da, da_interpolated):
     da_converted = da.convert_calendar("all_leap")
     years = get_list_of_years(da_converted)
+
+    # Calculate the rank of the index value for each day.
+    rank = da_interpolated.groupby("time.dayofyear").map(lambda x: x.rank("time"))
 
     cds_dict = {year: None for year in years}
     for year in years:
@@ -88,7 +91,11 @@ def calculate_individual_years(da):
         date = one_year_data.time.dt.strftime("%Y-%m-%d").values
         day_of_year = one_year_data.time.dt.dayofyear.values
         index_values = one_year_data.values
-        cds_dict[year] = ColumnDataSource({"date": date, "day_of_year": day_of_year, "index_values": index_values})
+        rank_values = rank.sel(time=one_year_data.time.values).values
+        cds_dict[year] = ColumnDataSource({"day_of_year": day_of_year,
+                                           "index_values": index_values,
+                                           "date": date,
+                                           "rank": rank_values})
 
     return cds_dict
 


### PR DESCRIPTION
This PR does the following:

- Implements a method for calculating the rank of values for a specific day of the year.
- Changes the hovertool of the individual yearly data to a custom hovertool so that the values of the index can be shown with a unit suffix.
- Removes the hovertools for the minimum and maximum values due the potential confusion they can cause for the user.

Resolves #16.