### PR TITLE
docker: fix missing dependency

### DIFF
--- a/docker/bokeh/requirements.txt
+++ b/docker/bokeh/requirements.txt
@@ -1,5 +1,6 @@
 netcdf4==1.5.8
 xarray
+bottleneck
 bokeh
 numpy
 matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ dependencies:
   - bokeh
   - netcdf4==1.5.8
   - xarray==2022.3.0
+  - bottleneck
   - numpy
   - cmcrameri
   - matplotlib


### PR DESCRIPTION
The bottleneck package is required to be able to use the rank method in
xarray.

Signed-off-by: Michael Yartys <michael.yartys@protonmail.com>