### PR TITLE
Fix initial calculation of climatology

### DIFF
--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -62,7 +62,11 @@ da = extracted_data["da"]
 # all leap calendar and interpolate to fill in for the missing February 29th values.
 da_converted = tk.convert_and_interpolate_calendar(da)
 
-percentiles_and_median_dict = tk.calculate_percentiles_and_median(da_converted)
+reference_period = reference_period_selector.value
+start_year = reference_period[:4]
+end_year = reference_period[5:]
+
+percentiles_and_median_dict = tk.calculate_percentiles_and_median(da_converted.sel(time=slice(start_year, end_year)))
 cds_percentile_1090 = percentiles_and_median_dict["cds_percentile_1090"]
 cds_percentile_2575 = percentiles_and_median_dict["cds_percentile_2575"]
 cds_median = percentiles_and_median_dict["cds_median"]


### PR DESCRIPTION
Instead of calculating the percentiles and median for the default reference period as was the intended behaviour, these climatologies were calculated for the entire length of the data. This happened because the data passed to the functions that calculate the percentiles and medians was never sliced to the reference period. Fix this.

Fixes #43.