### PR TITLE
Disable xarray caching

### DIFF
--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -42,7 +42,7 @@ def download_dataset(index, area):
     
     url_dict = {"sie": sie_dict, "sia": sia_dict}
 
-    return xr.open_dataset(url_dict[index][area])
+    return xr.open_dataset(url_dict[index][area], cache=False)
 
 
 def extract_data(ds, index):


### PR DESCRIPTION
During testing it was uncovered that data from the last couple of days does not get plotted. It is suspected that this could have something to do with caching. Disable this for now to see if it resolves the issue.