### PR TITLE
Change colour of the yearly data

### DIFF
--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -127,9 +127,13 @@ legend_list.append(("Min/Max", [minimum, maximum]))
 
 
 # Plot the individual years.
-colours_dict = tk.find_line_colours(cds_individual_years.keys(), color_scale_selector.value)
+data_years = tk.get_list_of_years(da)
+colours_dict = tk.find_line_colours(data_years[:-1], color_scale_selector.value)
 individual_years_glyphs = []
-for year, cds_individual_year in cds_individual_years.items():
+cds_individual_years_list = list(cds_individual_years.values())
+
+# Plot lines for all years except current one.
+for year, cds_individual_year in zip(data_years[:-1], cds_individual_years_list[:-1]):
     line_glyph = plot.line(x="day_of_year",
                            y="index_values",
                            source=cds_individual_year,
@@ -138,8 +142,22 @@ for year, cds_individual_year in cds_individual_years.items():
     legend_list.append((year, [line_glyph]))
     individual_years_glyphs.append(line_glyph)
 
-# Make sure the current year has a thicker line than the other years.
-line_glyph.glyph.line_width = 3
+# Plot the current year as two lines on top of each other (black and white dashed line).
+current_year_outline = plot.line(x="day_of_year",
+                                 y="index_values",
+                                 source=cds_individual_years_list[-1],
+                                 line_width=3,
+                                 line_color="black")
+
+current_year_filler = plot.line(x="day_of_year",
+                                y="index_values",
+                                source=cds_individual_years_list[-1],
+                                line_width=2,
+                                line_dash=[5, 5],
+                                line_color="white")
+
+legend_list.append((data_years[-1], [current_year_outline, current_year_filler]))
+individual_years_glyphs.append(current_year_outline)
 
 # To plot legends for the individual years we need to split the list of legends into several sublists. If we don't do
 # this the list will be so long that it's out of frame. The number below is the maximum number of elements that can
@@ -211,9 +229,8 @@ doy_minimum = da_converted.groupby("time.dayofyear").mean().idxmin().values.asty
 doy_maximum = da_converted.groupby("time.dayofyear").mean().idxmax().values.astype(int)
 
 # Add a bottom label with information about the data that's used to make the graphic.
-years = tk.get_list_of_years(da)
-first_year = years[0]
-second_to_last_year = years[-2]
+first_year = data_years[0]
+second_to_last_year = data_years[-2]
 
 
 def label_text(reference_period, first_year, second_to_last_year):
@@ -385,9 +402,10 @@ def set_zoom_yrange(padding_frac):
 
 def update_line_colour(attr, old, new):
     colour = color_scale_selector.value
-    colours_dict = tk.find_line_colours(cds_individual_years.keys(), colour)
+    data_years = list(cds_individual_years.keys())
+    colours_dict = tk.find_line_colours(data_years[:-1], colour)
 
-    for year, individual_year_glyph in zip(cds_individual_years.keys(), individual_years_glyphs):
+    for year, individual_year_glyph in zip(data_years[:-1], individual_years_glyphs[:-1]):
         individual_year_glyph.glyph.line_color = colours_dict[year]
 
 

--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -46,12 +46,12 @@ zoom_shortcuts = Select(title="Zoom shortcuts:",
 
 # Add a dropdown menu for selecting the colorscale that will be used for plotting the individual years.
 color_scale_selector = Select(title="Color scale of yearly data:",
-                              value="decadal",
-                              options=[("decadal", "By decade"),
-                                       ("viridis", "viridis"),
-                                       ("plasma", "plasma"),
-                                       ("batlow", "batlow"),
-                                       ("batlowS", "batlowS (CVD friendly)")])
+                              value="viridis",
+                              options=[("viridis", "Viridis"),
+                                       ("plasma", "Plasma"),
+                                       ("batlow", "Batlow"),
+                                       ("batlowS", "BatlowS"),
+                                       ("decadal", "Custom decadal")])
 
 # Download the data for the default index and area values.
 ds = tk.download_dataset(index_selector.value, area_selector.value)

--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -162,8 +162,6 @@ def find_line_colours(years, colour):
             full_colour_dict.update(decade_dict)
 
         colour_dict = {year: full_colour_dict[year] for year in years}
-        # Set the color of the current year to black.
-        colour_dict[list(years)[-1]] = "#000000"
 
     else:
         translation_dictionary = {"viridis": matplotlib.cm.viridis,
@@ -175,9 +173,5 @@ def find_line_colours(years, colour):
         colours = translation_dictionary[colour](normalised)
         colours_in_hex = [matplotlib.colors.to_hex(colour) for colour in colours]
         colour_dict = {year: colour for year, colour in zip(years, colours_in_hex)}
-
-        if colour in ("viridis", "plasma", "batlow"):
-            # Set the color of the current year to black.
-            colour_dict[list(years)[-1]] = "#000000"
 
     return colour_dict


### PR DESCRIPTION
* Make viridis the default colour map as it's CVD friendly, and change the order of the colour maps in the dropdown selection list.
* Change the current year to be plotted as two lines, one dashed white line on top of a thick solid black line. This ensures that the resulting line is easily distinguishable from other dashed black lines.