### PR TITLE
main: fix zoom state

### DIFF
--- a/bokeh-app/main.py
+++ b/bokeh-app/main.py
@@ -619,7 +619,7 @@ try:
             cds_yearly_min.data.update(new_cds_yearly_min.data)
 
             # Update the zoom to the new data using the current zoom state.
-            update_zoom(new_zoom=None)
+            update_zoom(zoom_state)
 
             # Update the plot title and x-axis label.
             plot.title.text = extracted_data["title"]


### PR DESCRIPTION
Make sure the callback that updates the data fetches the zoom state to move view to the same zoom level as previously selected.

Signed-off-by: Michael Yartys <michael.yartys@protonmail.com>