### PR TITLE
Add support for v3 of sea ice data

### DIFF
--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -6,27 +6,44 @@ import matplotlib
 import itertools
 
 
-def download_and_extract_data(index, area):
+def download_and_extract_data(version, index, area):
     url_prefix = "https://thredds.met.no/thredds/dodsC"
 
-    sie_dict = {"NH": f"{url_prefix}/osisaf/met.no/ice/index/v2p1/nh/osisaf_nh_sie_daily.nc",
-                "bar": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/bar/osisaf_bar_sie_daily.nc",
-                "beau": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/beau/osisaf_beau_sie_daily.nc",
-                "chuk": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/chuk/osisaf_chuk_sie_daily.nc",
-                "ess": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/ess/osisaf_ess_sie_daily.nc",
-                "fram": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/fram/osisaf_fram_sie_daily.nc",
-                "kara": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/kara/osisaf_kara_sie_daily.nc",
-                "lap": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/lap/osisaf_lap_sie_daily.nc",
-                "sval": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/sval/osisaf_sval_sie_daily.nc",
-                "SH": f"{url_prefix}/osisaf/met.no/ice/index/v2p1/sh/osisaf_sh_sie_daily.nc",
-                "bell": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/bell/osisaf_bell_sie_daily.nc",
-                "indi": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/indi/osisaf_indi_sie_daily.nc",
-                "ross": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/ross/osisaf_ross_sie_daily.nc",
-                "wedd": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/wedd/osisaf_wedd_sie_daily.nc",
-                "wpac": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/wpac/osisaf_wpac_sie_daily.nc",
-                "GLOBAL": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/glb/osisaf_glb_sie_daily.nc"}
+    sie_dict_v2 = {"NH": f"{url_prefix}/osisaf/met.no/ice/index/v2p1/nh/osisaf_nh_sie_daily.nc",
+                   "bar": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/bar/osisaf_bar_sie_daily.nc",
+                   "beau": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/beau/osisaf_beau_sie_daily.nc",
+                   "chuk": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/chuk/osisaf_chuk_sie_daily.nc",
+                   "ess": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/ess/osisaf_ess_sie_daily.nc",
+                   "fram": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/fram/osisaf_fram_sie_daily.nc",
+                   "kara": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/kara/osisaf_kara_sie_daily.nc",
+                   "lap": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/lap/osisaf_lap_sie_daily.nc",
+                   "sval": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/sval/osisaf_sval_sie_daily.nc",
+                   "SH": f"{url_prefix}/osisaf/met.no/ice/index/v2p1/sh/osisaf_sh_sie_daily.nc",
+                   "bell": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/bell/osisaf_bell_sie_daily.nc",
+                   "indi": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/indi/osisaf_indi_sie_daily.nc",
+                   "ross": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/ross/osisaf_ross_sie_daily.nc",
+                   "wedd": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/wedd/osisaf_wedd_sie_daily.nc",
+                   "wpac": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/wpac/osisaf_wpac_sie_daily.nc",
+                   "GLOBAL": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/glb/osisaf_glb_sie_daily.nc"}
 
-    sia_dict = {"NH": f"{url_prefix}/osisaf/met.no/ice/index/v2p1/nh/osisaf_nh_sia_daily.nc",
+    sie_dict_v3 = {"NH": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/nh/osisaf_nh_sie_daily.nc",
+                   "bar": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/bar/osisaf_bar_sie_daily.nc",
+                   "beau": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/beau/osisaf_beau_sie_daily.nc",
+                   "chuk": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/chuk/osisaf_chuk_sie_daily.nc",
+                   "ess": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/ess/osisaf_ess_sie_daily.nc",
+                   "fram": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/fram/osisaf_fram_sie_daily.nc",
+                   "kara": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/kara/osisaf_kara_sie_daily.nc",
+                   "lap": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/lap/osisaf_lap_sie_daily.nc",
+                   "sval": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/sval/osisaf_sval_sie_daily.nc",
+                   "SH": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/sh/osisaf_sh_sie_daily.nc",
+                   "bell": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/bell/osisaf_bell_sie_daily.nc",
+                   "indi": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/indi/osisaf_indi_sie_daily.nc",
+                   "ross": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/ross/osisaf_ross_sie_daily.nc",
+                   "wedd": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/wedd/osisaf_wedd_sie_daily.nc",
+                   "wpac": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/wpac/osisaf_wpac_sie_daily.nc",
+                   "GLOBAL": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/glb/osisaf_glb_sie_daily.nc"}
+
+    sia_dict_v2 = {"NH": f"{url_prefix}/osisaf/met.no/ice/index/v2p1/nh/osisaf_nh_sia_daily.nc",
                 "bar": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/bar/osisaf_bar_sia_daily.nc",
                 "beau": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/beau/osisaf_beau_sia_daily.nc",
                 "chuk": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/chuk/osisaf_chuk_sia_daily.nc",
@@ -42,9 +59,29 @@ def download_and_extract_data(index, area):
                 "wedd": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/wedd/osisaf_wedd_sia_daily.nc",
                 "wpac": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/wpac/osisaf_wpac_sia_daily.nc",
                 "GLOBAL": f"{url_prefix}/metusers/thomasl/OSI420_moreRegions/glb/osisaf_glb_sia_daily.nc"}
-    
-    url_dict = {"sie": sie_dict, "sia": sia_dict}
-    ds = xr.open_dataset(url_dict[index][area], cache=False)
+
+    sia_dict_v3 = {"NH": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/nh/osisaf_nh_sia_daily.nc",
+                   "bar": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/bar/osisaf_bar_sia_daily.nc",
+                   "beau": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/beau/osisaf_beau_sia_daily.nc",
+                   "chuk": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/chuk/osisaf_chuk_sia_daily.nc",
+                   "ess": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/ess/osisaf_ess_sia_daily.nc",
+                   "fram": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/fram/osisaf_fram_sia_daily.nc",
+                   "kara": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/kara/osisaf_kara_sia_daily.nc",
+                   "lap": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/lap/osisaf_lap_sia_daily.nc",
+                   "sval": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/sval/osisaf_sval_sia_daily.nc",
+                   "SH": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/sh/osisaf_sh_sia_daily.nc",
+                   "bell": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/bell/osisaf_bell_sia_daily.nc",
+                   "indi": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/indi/osisaf_indi_sia_daily.nc",
+                   "ross": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/ross/osisaf_ross_sia_daily.nc",
+                   "wedd": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/wedd/osisaf_wedd_sia_daily.nc",
+                   "wpac": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/wpac/osisaf_wpac_sia_daily.nc",
+                   "GLOBAL": f"{url_prefix}/metusers/thomasl/OSI420_BetaFromSICv3/glb/osisaf_glb_sia_daily.nc"}
+
+    version_2 = {"sie": sie_dict_v2, "sia": sia_dict_v2}
+    version_3 = {"sie": sie_dict_v3, "sia": sia_dict_v3}
+    version_dict = {"v2": version_2, "v3": version_3}
+
+    ds = xr.open_dataset(version_dict[version][index][area], cache=False)
 
     da = ds[index]
     title = ds.title


### PR DESCRIPTION
This PR adds support for the new version of the sea ice data. Specifying the version of data is done in the URL by adding `?version=` to the end of the URL together with either `v2` or `v3`.