### PR TITLE
Update dependencies

### DIFF
--- a/docker/bokeh/requirements.txt
+++ b/docker/bokeh/requirements.txt
@@ -1,8 +1,8 @@
 netcdf4==1.6.3
 xarray==2023.05.0
-bottleneck
-panel==1.0.3
+bottleneck==1.3.7
+panel==1.0.4
 bokeh==3.1.1
-numpy
-matplotlib
-cmcrameri
+numpy==1.24.3
+matplotlib==3.7.1
+cmcrameri==1.4

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 dependencies:
   - python==3.11.3
-  - panel==1.0.3
+  - panel==1.0.4
   - bokeh==3.1.1
   - netcdf4==1.6.3
   - xarray==2023.05.0
-  - bottleneck
-  - numpy
-  - cmcrameri
-  - matplotlib
+  - bottleneck==1.3.7
+  - numpy==1.24.3
+  - cmcrameri==1.4
+  - matplotlib==3.7.1


### PR DESCRIPTION
Update panel to 1.0.4 as this version fixes the loading spinner. Freeze all dependencies to minimise the risk of bugs due to different package versions.