### PR TITLE
Prevent plot lines from overlapping with text label

### DIFF
--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -310,11 +310,6 @@ def find_yearly_min_max(da_converted, fill_colors_dict):
     return cds_yearly_max, cds_yearly_min
 
 
-def find_nice_ylimit(da):
-    """Find an upper y-limit with 10 percent added to the maximum value of the data."""
-    return 1.10 * da.max().values
-
-
 def find_nice_yrange(monthly_data, trend_data, padding_mult, min_span):
     """Function to find a nice y-range that is not too narrow."""
     all_monthly_data = np.concatenate((monthly_data, trend_data))


### PR DESCRIPTION
This pull request changes the daily plot to calculate the y-range in such a way that it takes the height of the text label in the lower left corner into account to not have any plot elements overlapping with it. The y-range is calculated for all plot shortcuts, and also when the plot is opened. The start and end values also get a small amount of padding to ensure that no plot elements are touching the top of the plot frame or the top of the text label. This leads to the y-range often containing negative y-values. A thick grey line has therefore been added on y=0 to make it stand out.

Here are some screenshots showing what this looks like for a few regions:


![Screenshot from 2024-04-19 14-46-36](https://github.com/metno/sea-ice-index-viz/assets/33153877/cefef2f9-6467-4782-90bf-2f006fb28baf)
![Screenshot from 2024-04-19 14-46-55](https://github.com/metno/sea-ice-index-viz/assets/33153877/28bddb26-59cc-4026-b831-5643d6181610)
![Screenshot from 2024-04-19 14-47-16](https://github.com/metno/sea-ice-index-viz/assets/33153877/1b43e3b4-50ae-4715-8eb9-de9acfb351b7)
![Screenshot from 2024-04-19 14-47-32](https://github.com/metno/sea-ice-index-viz/assets/33153877/5aa62a10-814c-4e61-9de5-d07d5a334e0d)





Resolves #114.