### PR TITLE
Add TOPAZ5 forecasts

### DIFF
--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -335,6 +335,18 @@ def visualisation():
         visible=False,
     )
 
+    ensemble_members = []
+    for index, cds in data.cds_forecasts.items():
+        forecast = plot.line(
+            x='doy',
+            y='value',
+            source=cds,
+            line_width=2,
+            line_color='black',
+        )
+
+        ensemble_members.append(forecast)
+
     last_year_outline = plot.line(
         x='doy',
         y='value',
@@ -360,6 +372,7 @@ def visualisation():
     legend_list.extend(decades)
     legend_list.extend(yearly)
     legend_list.append((years[-1], [last_year_outline, last_year_inner]))
+    legend_list.append(('Forecast', ensemble_members))
 
     n = 23
     legend_split = [
@@ -377,11 +390,12 @@ def visualisation():
         last_year_outline
     ]
     tooltips = Tooltips(
-        plot_type_selector.value, all_yearly_glyphs, [yearly_min], [yearly_max]
+        plot_type_selector.value, all_yearly_glyphs, [yearly_min], [yearly_max], ensemble_members
     )
     plot.add_tools(tooltips.yearly)
     plot.add_tools(tooltips.min)
     plot.add_tools(tooltips.max)
+    plot.add_tools(tooltips.forecast)
 
     def update_attrs(attr, old, new):
         first_year = int(data.ds_daily.time[0].dt.year.values)
@@ -462,6 +476,9 @@ def visualisation():
                 for year in yearly:
                     year[1][0].visible = False
 
+                for ens_mem in ensemble_members:
+                    ens_mem.visible = False
+
                 last_year_outline.visible = False
                 last_year_inner.visible = False
 
@@ -481,6 +498,9 @@ def visualisation():
 
                 for year in yearly:
                     year[1][0].visible = True
+
+                for ens_mem in ensemble_members:
+                    ens_mem.visible = True
 
                 last_year_outline.visible = True
                 last_year_inner.visible = True
@@ -507,6 +527,9 @@ def visualisation():
                 for year in yearly[-5:]:
                     year[1][0].visible = True
 
+                for ens_mem in ensemble_members:
+                    ens_mem.visible = True
+
                 last_year_outline.visible = True
                 last_year_inner.visible = True
 
@@ -523,6 +546,9 @@ def visualisation():
 
                 yearly_min.visible = False
                 yearly_max.visible = False
+
+                for ens_mem in ensemble_members:
+                    ens_mem.visible = True
 
                 last_year_outline.visible = True
                 last_year_inner.visible = True

--- a/bokeh-app/plot_tools.py
+++ b/bokeh-app/plot_tools.py
@@ -153,6 +153,7 @@ class Tooltips:
         yearly_glyphs: list,
         min_glyphs: list,
         max_glyphs: list,
+        forecast_glyphs: list,
     ) -> None:
         self.yearly = HoverTool(
             renderers=yearly_glyphs,
@@ -170,6 +171,11 @@ class Tooltips:
             renderers=max_glyphs,
             tooltips=self.yr_max_tooltips(self._value_fmt(anom)),
             formatters={'@rank': self._rank_fmt()},
+            visible=False,
+        )
+        self.forecast = HoverTool(
+            renderers=forecast_glyphs,
+            tooltips=self.forecast_tooltips(self._value_fmt(anom)),
             visible=False,
         )
 
@@ -267,6 +273,26 @@ class Tooltips:
         )
 
         return rank_fmt
+
+    def forecast_tooltips(self, fmt: str) -> str:
+        tooltips = f"""
+                <div>
+                    <div>
+                        <span style="font-size: 14px; font-weight: bold;">TOPAZ5 (member @member)</span>
+                    </div>
+                    <div>
+                        <span style="font-size: 12px; font-weight: bold">Date:</span>
+                        <span style="font-size: 12px;">@date</span>
+                    </div>
+                    <div>
+                        <span style="font-size: 12px; font-weight: bold">Index:</span>
+                        <span style="font-size: 12px;">@value{{{fmt}}}</span>
+                        <span style="font-size: 12px;">mill. km<sup>2</sup></span>
+                    </div>
+                </div>
+                """
+
+        return tooltips
 
 
 def set_zoom_yrange(

--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -12,7 +12,7 @@ class VisDataDaily:
     def __init__(
         self, anomaly: str, index: str, area: str, ref_period: str, cmap: str
     ) -> None:
-        self.ds_daily, ds_clim, ds_decades = self._download_data(
+        self.ds_daily, ds_clim, ds_decades, ds_forecast = self._download_data(
             anomaly, index, area, ref_period
         )
 
@@ -54,10 +54,15 @@ class VisDataDaily:
             self._year_max(self.ds_daily, cols)
         )
 
+        self.cds_forecasts = {}
+        for i in range(1, 11):
+            da = ds_forecast[index].sel(member=i)
+            self.cds_forecasts[i] = ColumnDataSource(self._forecast(da))
+
     def update_data(
         self, anomaly: str, index: str, area: str, ref_period: str, cmap: str
     ) -> None:
-        self.ds_daily, ds_clim, ds_decades = self._download_data(
+        self.ds_daily, ds_clim, ds_decades, ds_forecast = self._download_data(
             anomaly, index, area, ref_period
         )
 
@@ -91,6 +96,10 @@ class VisDataDaily:
         self.cds_yearly_min.data.update(self._year_min(self.ds_daily, cols))
         self.cds_yearly_max.data.update(self._year_max(self.ds_daily, cols))
 
+        for i in range(1, 11):
+            da = ds_forecast[index].sel(member=i)
+            self.cds_forecasts[i].data.update(self._forecast(da))
+
     def update_colour(self, cmap: str) -> None:
         cols = [
             self.colours[cmap][str(year)] for year in self.ds_daily.year.values
@@ -106,7 +115,7 @@ class VisDataDaily:
 
     def _download_data(
         self, anomaly: str, index: str, area: str, ref_period: str
-    ) -> tuple[xr.Dataset, xr.Dataset, dict[str, xr.Dataset]]:
+    ) -> tuple[xr.Dataset, xr.Dataset, dict[str, xr.Dataset], xr.Dataset]:
         dir = ('https://thredds.met.no/thredds/dodsC/metusers/signeaa/'
                'test-data-sii-v3p0')
 
@@ -139,12 +148,32 @@ class VisDataDaily:
 
         ds_clim = ds_clims[ref_period]
 
+        dir = (
+            'https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
+            'SII_forecast'
+        )
+        try:
+            ds_forecast = xr.open_dataset(
+                f'{dir}/{index}_{area}.nc', cache=False
+            ).load()
+        except OSError:
+            # Create a fake Dataset when forecast data does not exist for a
+            # given region. This can for example be for regions in the
+            # southern hemisphere.
+            values = np.full((10, 1), np.nan)
+            data_vars = {index: (['member', 'time'], values)}
+            coords = {
+                'member': [i for i in range(1, 11)],
+                'time': [np.datetime64('1970-01-01')],
+            }
+            ds_forecast = xr.Dataset(data_vars=data_vars, coords=coords)
+
         if anomaly == 'anom':
-            ds_daily, ds_clim, ds_decades = self._get_anomaly(
-                index, ref_period, ds_daily, ds_clim, ds_decades
+            ds_daily, ds_clim, ds_decades, ds_forecast = self._get_anomaly(
+                index, ref_period, ds_daily, ds_clim, ds_decades, ds_forecast
             )
 
-        return ds_daily, ds_clim, ds_decades
+        return ds_daily, ds_clim, ds_decades, ds_forecast
 
     def _get_anomaly(
         self,
@@ -153,7 +182,8 @@ class VisDataDaily:
         ds_daily: xr.Dataset,
         ds_clim: xr.Dataset,
         ds_decades: dict[str, xr.Dataset],
-    ) -> tuple[xr.Dataset, xr.Dataset, dict[str, xr.Dataset]]:
+        ds_forecast: xr.Dataset,
+    ) -> tuple[xr.Dataset, xr.Dataset, dict[str, xr.Dataset], xr.Dataset]:
         start = ref_period[:4]
         end = ref_period[5:]
 
@@ -221,7 +251,12 @@ class VisDataDaily:
         ds_daily['yearly_min_value'].values = year_min
         ds_daily['yearly_max_value'].values = year_max
 
-        return ds_daily, ds_clim, ds_decades
+        doy = ds_forecast.time.dt.dayofyear.values
+        ds_forecast[index].values = (
+            ds_forecast[index].values - mean.sel(dayofyear=doy).values
+        )
+
+        return ds_daily, ds_clim, ds_decades, ds_forecast
 
     def _p10_90(self, ds: xr.Dataset, index: str) -> dict[str, NDArray[float]]:
         return {
@@ -290,6 +325,14 @@ class VisDataDaily:
             'date': ds.yearly_max_date.dt.strftime('%Y-%m-%d').values,
             'rank': ds.yearly_max_rank.values,
             'colour': colours,
+        }
+
+    def _forecast(self, da: xr.DataArray):
+        return {
+            'doy': da.time.dt.dayofyear.values,
+            'value': da.values,
+            'member': np.full(len(da.values), da.member.values),
+            'date': da.time.dt.strftime('%Y-%m-%d').values,
         }
 
     def _get_colours(self, years: NDArray) -> dict[str, NDArray[str]]:


### PR DESCRIPTION
Add TOPAZ5 forecasts to the daily visualisation. Currently, the implementation has the following limitations:

* Not all regions have a TOPAZ5 forecast. For the southern hemisphere regions and global region this is just a consequence of TOPAZ5 only producing forecasts for the northern hemisphere. However, several subregions in the northern hemisphere also lack a forecast. This is due to ICECAP, which is used to produce the TOPAZ5 forecast data files, not supporting Met's own region file, only that of NSIDC. The following region in the northern hemisphere is missing data because of this: sval (Svalbard).
* The legend of the forecast glyphs is shown and is clickable even for regions that do not have forecast data.