### PR TITLE
Remove Alaska as a region

### DIFF
--- a/bokeh-app/plot_tools.py
+++ b/bokeh-app/plot_tools.py
@@ -23,7 +23,6 @@ class AreaNames:
             'chukchi': 'Chukchi Sea',
             'greenland': 'East Greenland Sea',
             'ess': 'East Siberian Sea',
-            'alaska': 'Gulf of Alaska',
             'lawrence': 'Gulf of St. Lawrence',
             'hudson': 'Hudson Bay',
             'kara': 'Kara Sea',


### PR DESCRIPTION
There is no data available for Alaska in v3.0, so there is no point in keeping it as a region.