### PR TITLE
Reduce the amount of legend columns

### DIFF
--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -27,7 +27,7 @@ pn.extension(exception_handler=exception_handler, notifications=True)
 
 # Add a parameter for setting the desired version of the sea ice data, and sync to url parameter.
 class VersionUrlParameter(param.Parameterized):
-    value = param.Parameter("v2p2")
+    value = param.Parameter("v2p3")
 
 
 pn.state.location.sync(VersionUrlParameter, {'value': 'version'})
@@ -507,6 +507,9 @@ try:
         cdr_version = "v2.1"
     elif extracted_data["ds_version"] == "v2p2":
         version_label = "v2.2"
+        cdr_version = "v3"
+    elif extracted_data["ds_version"] == "v2p3":
+        version_label = "v2.3"
         cdr_version = "v3"
 
     label_text = f"Median and percentiles (25-75% and 10-90%) for {reference_period_selector.value}, " \

--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -356,7 +356,7 @@ try:
     # elements that can be inside one sublist. This number was determined with basic testing on one specific
     # computer. This is an issue because other clients can have computers with a different screen resolution which
     # can fit more legends. Keep this solution for now, but check if there's a better way to solve this.
-    n = 23
+    n = 30
     legend_split = [legend_list[i:i+n] for i in range(0, len(legend_list), n)]
 
     for sublist in legend_split:

--- a/bokeh-app/monthly/main.py
+++ b/bokeh-app/monthly/main.py
@@ -28,7 +28,7 @@ pn.extension(exception_handler=exception_handler, notifications=True)
 
 # Add a parameter for setting the desired version of the sea ice data, and sync to url parameter.
 class VersionUrlParameter(param.Parameterized):
-    value = param.Parameter("v2p2")
+    value = param.Parameter("v2p3")
 
 
 pn.state.location.sync(VersionUrlParameter, {"value": "version"})
@@ -298,6 +298,9 @@ try:
         cdr_version = "v2.1"
     elif extracted_data["ds_version"] == "v2p2":
         version_label = "v2.2"
+        cdr_version = "v3"
+    elif extracted_data["ds_version"] == "v2p3":
+        version_label = "v2.3"
         cdr_version = "v3"
 
     last_month_string = str(da.time[-1].dt.strftime('%Y-%m').values)


### PR DESCRIPTION
Do the same in v2p3 as in v3p0 and reduce the amount of legend columns from three to two in order to use the horizontal space better.