### PR TITLE
Add 5-day rolling mean functionality

### DIFF
--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -120,8 +120,15 @@ def visualisation():
     )
     pn.state.location.sync(grid_selector, {'value': 'grid'})
 
+    rolling_selector = pn.widgets.Select(name='5-day rolling mean:',
+                                         options={'On': 'on', 'Off': 'off'},
+                                         value='off',
+                                         sizing_mode='stretch_width')
+    pn.state.location.sync(rolling_selector, {'value': 'rolling'})
+
     data = VisDataDaily(
         plot_type_selector.value,
+        rolling_selector.value,
         index_selector.value,
         area_selector.value,
         reference_period_selector.value,
@@ -383,6 +390,7 @@ def visualisation():
             try:
                 data.update_data(
                     plot_type_selector.value,
+                    rolling_selector.value,
                     index_selector.value,
                     area_selector.value,
                     reference_period_selector.value,
@@ -575,6 +583,7 @@ def visualisation():
         zoom_shortcuts,
         cmap_selector,
         grid_selector,
+        rolling_selector,
     )
 
     gspec = pn.GridSpec(sizing_mode='stretch_both')
@@ -594,6 +603,7 @@ def visualisation():
     zoom_shortcuts.param.watch(update_zoom, 'clicked', onlychanged=False)
     cmap_selector.param.watch(update_colour, 'value')
     grid_selector.param.watch(update_grid, 'value')
+    rolling_selector.param.watch(update_data, 'value')
 
     def read_params(event):
         # Read plot shortcut URL parameter if there is one and update the

--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 
 class VisDataDaily:
     def __init__(
-        self, anomaly: str, index: str, area: str, ref_period: str, cmap: str
+        self, anomaly: str, rolling: str, index: str, area: str, ref_period: str, cmap: str
     ) -> None:
         self.ds_daily, ds_clim, ds_decades, ds_forecast = self._download_data(
             anomaly, index, area, ref_period
@@ -34,6 +34,10 @@ class VisDataDaily:
         years = np.unique(self.ds_daily.time.dt.year.values).astype(str)
 
         da = self.ds_daily[index].convert_calendar('all_leap')
+
+        if rolling == 'on':
+            da = da.rolling(time=5, center=True).mean()
+
         self.cds_yearly = {}
         for year in years:
             subset = da.sel(time=year)
@@ -60,7 +64,7 @@ class VisDataDaily:
             self.cds_forecasts[i] = ColumnDataSource(self._forecast(da))
 
     def update_data(
-        self, anomaly: str, index: str, area: str, ref_period: str, cmap: str
+        self, anomaly: str, rolling: str, index: str, area: str, ref_period: str, cmap: str
     ) -> None:
         self.ds_daily, ds_clim, ds_decades, ds_forecast = self._download_data(
             anomaly, index, area, ref_period
@@ -83,6 +87,9 @@ class VisDataDaily:
         years = np.unique(self.ds_daily.time.dt.year.values).astype(str)
 
         da = self.ds_daily[index].convert_calendar('all_leap')
+        if rolling == 'on':
+            da = da.rolling(time=5, center=True).mean()
+
         for year in years:
             subset = da.sel(time=year)
             rank = self.ds_daily.rank_per_doy.sel(time=year)


### PR DESCRIPTION
Add a very provisional 5-day running mean functionality at the request of @signeaa. The current implementation only applies the 5-day running mean to the daily values (the glyphs of the individual years).

Closes #163.