### PR TITLE
Increase legend column length

### DIFF
--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -329,7 +329,7 @@ def visualisation():
     legend_list.extend(yearly)
     legend_list.append((years[-1], [last_year_outline, last_year_inner]))
 
-    n = 28
+    n = 29
     legend_split = [
         legend_list[i: i + n] for i in range(0, len(legend_list), n)
     ]


### PR DESCRIPTION
Increase the legend column length by one in order to retain the two-column layout for when we have data up to and including 2028. This causes the legend to partially obscure the following x-tick: "31 Dec".