### PR TITLE
Improve daily forecast visualisation

### DIFF
--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -63,6 +63,14 @@ def visualisation():
     )
     pn.state.location.sync(reference_period_selector, {'value': 'ref'})
 
+    forecast_selector = pn.widgets.Select(
+        name='Forecast:',
+        options=['TOPAZ5', 'ECMWF', 'DWD'],
+        value='TOPAZ5',
+        sizing_mode='stretch_width',
+    )
+    pn.state.location.sync(forecast_selector, {'value': 'forecast'})
+
     plot_shortcuts = pn.widgets.MenuButton(
         name='Plot shortcuts',
         items=[
@@ -135,6 +143,7 @@ def visualisation():
         index_selector.value,
         area_selector.value,
         reference_period_selector.value,
+        forecast_selector.value,
         cmap_selector.value,
     )
 
@@ -305,17 +314,23 @@ def visualisation():
         visible=False,
     )
 
-    ensemble_members = []
-    for index, cds in data.cds_forecasts.items():
-        forecast = plot.line(
-            x='doy',
-            y='value',
-            source=cds,
-            line_width=2,
-            line_color='black',
-        )
+    forecast_span = plot.varea(
+        x='doy',
+        y1='min',
+        y2='max',
+        source=data.cds_forecast_span,
+        fill_alpha=0.3,
+        fill_color='red',
+    )
 
-        ensemble_members.append(forecast)
+    forecast_median = plot.line(
+        x='doy',
+        y='median',
+        source=data.cds_forecast_span,
+        line_width=2,
+        line_alpha=0.5,
+        line_color='red',
+    )
 
     last_year_outline = plot.line(
         x='doy',
@@ -342,7 +357,7 @@ def visualisation():
     legend_list.extend(decades)
     legend_list.extend(yearly)
     legend_list.append((years[-1], [last_year_outline, last_year_inner]))
-    legend_list.append(('Forecast', ensemble_members))
+    legend_list.append(('Forecast', [forecast_span, forecast_median]))
 
     n = 30
     legend_split = [
@@ -364,7 +379,7 @@ def visualisation():
         all_yearly_glyphs,
         [yearly_min],
         [yearly_max],
-        ensemble_members,
+        [forecast_span],
     )
     plot.add_tools(tooltips.yearly)
     plot.add_tools(tooltips.min)
@@ -400,6 +415,7 @@ def visualisation():
                     index_selector.value,
                     area_selector.value,
                     reference_period_selector.value,
+                    forecast_selector.value,
                     cmap_selector.value,
                 )
             except OSError:
@@ -450,8 +466,8 @@ def visualisation():
                 for year in yearly:
                     year[1][0].visible = False
 
-                for ens_mem in ensemble_members:
-                    ens_mem.visible = False
+                for forecast in [forecast_span, forecast_median]:
+                    forecast.visible = False
 
                 last_year_outline.visible = False
                 last_year_inner.visible = False
@@ -473,8 +489,8 @@ def visualisation():
                 for year in yearly:
                     year[1][0].visible = True
 
-                for ens_mem in ensemble_members:
-                    ens_mem.visible = True
+                for forecast in [forecast_span, forecast_median]:
+                    forecast.visible = True
 
                 last_year_outline.visible = True
                 last_year_inner.visible = True
@@ -501,8 +517,8 @@ def visualisation():
                 for year in yearly[-5:]:
                     year[1][0].visible = True
 
-                for ens_mem in ensemble_members:
-                    ens_mem.visible = True
+                for forecast in [forecast_span, forecast_median]:
+                    forecast.visible = True
 
                 last_year_outline.visible = True
                 last_year_inner.visible = True
@@ -521,8 +537,8 @@ def visualisation():
                 yearly_min.visible = False
                 yearly_max.visible = False
 
-                for ens_mem in ensemble_members:
-                    ens_mem.visible = True
+                for forecast in [forecast_span, forecast_median]:
+                    forecast.visible = True
 
                 last_year_outline.visible = True
                 last_year_inner.visible = True
@@ -585,6 +601,7 @@ def visualisation():
         index_selector,
         area_selector,
         reference_period_selector,
+        forecast_selector,
         plot_shortcuts,
         zoom_shortcuts,
         cmap_selector,
@@ -609,6 +626,7 @@ def visualisation():
     index_selector.param.watch(update_data, 'value')
     area_selector.param.watch(update_data, 'value')
     reference_period_selector.param.watch(update_data, 'value')
+    forecast_selector.param.watch(update_data, 'value')
     plot_shortcuts.param.watch(
         shortcuts_callback, 'clicked', onlychanged=False
     )

--- a/bokeh-app/plot_tools.py
+++ b/bokeh-app/plot_tools.py
@@ -271,15 +271,25 @@ class Tooltips:
         tooltips = f"""
                 <div>
                     <div>
-                        <span style="font-size: 14px; font-weight: bold;">TOPAZ5 (member @member)</span>
+                        <span style="font-size: 14px; font-weight: bold;">@model</span>
                     </div>
                     <div>
                         <span style="font-size: 12px; font-weight: bold">Date:</span>
                         <span style="font-size: 12px;">@date</span>
                     </div>
                     <div>
-                        <span style="font-size: 12px; font-weight: bold">Index:</span>
-                        <span style="font-size: 12px;">@value{{{fmt}}}</span>
+                        <span style="font-size: 12px; font-weight: bold">Max:</span>
+                        <span style="font-size: 12px;">@max{{{fmt}}}</span>
+                        <span style="font-size: 12px;">mill. km<sup>2</sup></span>
+                    </div>
+                    <div>
+                        <span style="font-size: 12px; font-weight: bold">Median:</span>
+                        <span style="font-size: 12px;">@median{{{fmt}}}</span>
+                        <span style="font-size: 12px;">mill. km<sup>2</sup></span>
+                    </div>
+                    <div>
+                        <span style="font-size: 12px; font-weight: bold">Min:</span>
+                        <span style="font-size: 12px;">@min{{{fmt}}}</span>
                         <span style="font-size: 12px;">mill. km<sup>2</sup></span>
                     </div>
                 </div>

--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -10,10 +10,10 @@ from numpy.typing import NDArray
 
 class VisDataDaily:
     def __init__(
-        self, anomaly: str, rolling: str, index: str, area: str, ref_period: str, cmap: str
+        self, anomaly: str, rolling: str, index: str, area: str, ref_period: str, forecast: str, cmap: str
     ) -> None:
         self.ds_daily, ds_clim, ds_decades, ds_forecast = self._download_data(
-            anomaly, index, area, ref_period
+            anomaly, index, area, ref_period, forecast
         )
 
         self.cds_p10_90 = ColumnDataSource(self._p10_90(ds_clim, index))
@@ -58,16 +58,15 @@ class VisDataDaily:
             self._year_max(self.ds_daily, cols)
         )
 
-        self.cds_forecasts = {}
-        for i in range(1, 11):
-            da = ds_forecast[index].sel(member=i)
-            self.cds_forecasts[i] = ColumnDataSource(self._forecast(da))
+        da = ds_forecast[index].quantile([0, 0.5, 1], dim='member')
+
+        self.cds_forecast_span = ColumnDataSource(self._forecast_varea(da, forecast))
 
     def update_data(
-        self, anomaly: str, rolling: str, index: str, area: str, ref_period: str, cmap: str
+        self, anomaly: str, rolling: str, index: str, area: str, ref_period: str, forecast: str, cmap: str
     ) -> None:
         self.ds_daily, ds_clim, ds_decades, ds_forecast = self._download_data(
-            anomaly, index, area, ref_period
+            anomaly, index, area, ref_period, forecast
         )
 
         self.cds_p10_90.data.update(self._p10_90(ds_clim, index))
@@ -103,9 +102,9 @@ class VisDataDaily:
         self.cds_yearly_min.data.update(self._year_min(self.ds_daily, cols))
         self.cds_yearly_max.data.update(self._year_max(self.ds_daily, cols))
 
-        for i in range(1, 11):
-            da = ds_forecast[index].sel(member=i)
-            self.cds_forecasts[i].data.update(self._forecast(da))
+        da = ds_forecast[index].quantile([0, 0.5, 1], dim='member')
+
+        self.cds_forecast_span.data.update(self._forecast_varea(da, forecast))
 
     def update_colour(self, cmap: str) -> None:
         cols = [
@@ -121,7 +120,7 @@ class VisDataDaily:
         self.cds_yearly_max.data.update(yearly_max)
 
     def _download_data(
-        self, anomaly: str, index: str, area: str, ref_period: str
+        self, anomaly: str, index: str, area: str, ref_period: str, forecast: str
     ) -> tuple[xr.Dataset, xr.Dataset, dict[str, xr.Dataset], xr.Dataset]:
         dir = 'https://thredds.met.no/thredds/dodsC/osisaf/met.no/ice/index'
 
@@ -154,10 +153,16 @@ class VisDataDaily:
 
         ds_clim = ds_clims[ref_period]
 
-        dir = (
-            'https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
-            'SII_forecast/final_topaz5'
-        )
+        if forecast == 'TOPAZ5':
+            dir = ('https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
+                   'SII_forecast/final_topaz5')
+        elif forecast == 'ECMWF':
+            dir = ('https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
+                   'SII_forecast/final_ecmwf')
+        else:
+            dir = ('https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
+                   'SII_forecast/final_dwd')
+
         try:
             ds_forecast = xr.open_dataset(
                 f'{dir}/{index}_{area}.nc', cache=False
@@ -333,10 +338,9 @@ class VisDataDaily:
             'colour': colours,
         }
 
-    def _forecast(self, da: xr.DataArray):
+    def _forecast_median(self, da: xr.DataArray):
         doy = da.time.dt.dayofyear.values
-        values = da.values
-        member = np.full(len(da.values), da.member.values)
+        values = da.sel(quantile=0.5).values
         dates = da.time.dt.strftime('%Y-%m-%d').values
 
         # Check whether dayofyear array contains both 1 and 366 which
@@ -347,15 +351,40 @@ class VisDataDaily:
             year_start_index = np.where(doy == 1)[0]
             doy = np.insert(doy, year_start_index, 367)
             values = np.insert(values, year_start_index, np.nan)
-            member = np.insert(member, year_start_index, 999)
             dates = np.insert(dates, year_start_index, 'FAKE')
 
         return {
             'doy': doy,
             'value': values,
-            'member': member,
             'date': dates,
         }
+
+    def _forecast_varea(self, da: xr.DataArray, model: str):
+        doy = da.time.dt.dayofyear.values
+
+        min = da.sel(quantile=0).values
+        median = da.sel(quantile=0.5).values
+        max = da.sel(quantile=1).values
+        dates = da.time.dt.strftime('%Y-%m-%d').values
+
+        # Check whether dayofyear array contains both 1 and 366 which
+        # indicates that it runs into the next year. We then need to insert
+        # a nan-value in the values array, and placeholder fake values in
+        # the other arrays.
+        if sum(np.isin(doy, [366, 1])) == 2:
+            year_start_index = np.where(doy == 1)[0]
+            doy = np.insert(doy, year_start_index, 367)
+            min = np.insert(min, year_start_index, np.nan)
+            median = np.insert(median, year_start_index, np.nan)
+            max = np.insert(max, year_start_index, np.nan)
+            dates = np.insert(dates, year_start_index, 'FAKE')
+
+        return {'model': np.full(doy.shape, model),
+                'doy': doy,
+                'min': min,
+                'median': median,
+                'max': max,
+                'date': dates}
 
     def _get_colours(self, years: NDArray) -> dict[str, NDArray[str]]:
         colours = {}


### PR DESCRIPTION
This PR does the following:

* Make it possible to visualise ECMWF and DWD forecasts in addition to TOPAZ5.
* Change the glyphs of the forecast to show the full range of the forecast members (0 to 100 percentile), in addition to the median.