### PR TITLE
Add support for CMCC forecasts

### DIFF
--- a/bokeh-app/daily/main.py
+++ b/bokeh-app/daily/main.py
@@ -65,7 +65,7 @@ def visualisation():
 
     forecast_selector = pn.widgets.Select(
         name='Forecast:',
-        options=['TOPAZ5', 'ECMWF', 'DWD'],
+        options=['CMCC', 'DWD', 'ECMWF', 'TOPAZ5'],
         value='TOPAZ5',
         sizing_mode='stretch_width',
     )

--- a/bokeh-app/toolkit.py
+++ b/bokeh-app/toolkit.py
@@ -183,20 +183,30 @@ class VisDataDaily:
 
         ds_clim = ds_clims[ref_period]
 
-        if forecast == 'TOPAZ5':
+        if forecast == 'CMCC':
             dir = (
                 'https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
-                'SII_forecast/final_topaz5'
+                'SII_forecast/final_cmcc'
+            )
+        elif forecast == 'DWD':
+            dir = (
+                'https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
+                'SII_forecast/final_dwd'
             )
         elif forecast == 'ECMWF':
             dir = (
                 'https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
                 'SII_forecast/final_ecmwf'
             )
-        else:
+        elif forecast == 'TOPAZ5':
             dir = (
                 'https://thredds.met.no/thredds/dodsC/metusers/thomasl/'
-                'SII_forecast/final_dwd'
+                'SII_forecast/final_topaz5'
+            )
+        else:
+            raise ValueError(
+                f'Invalid forecast variable "{forecast}"! Only the following '
+                'forecasts are supported: CMCC, DWD, ECMWF, TOPAZ5.'
             )
 
         try:


### PR DESCRIPTION
This PR makes the following changes:

* Makes it possible to fetch CMCC forecasts.
* Adds CMCC to the list of forecasts that can be selected in the forecast widget, and reorders the forecasts according to alphabetical order.